### PR TITLE
nits from PR #29

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,20 +20,20 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.4</version>
+        <groupId>org.eclipse.ee4j.management-api</groupId>
+        <artifactId>management-api-parent</artifactId>
+        <version>1.1.3-SNAPSHOT</version>
     </parent>
 
     <groupId>jakarta.management.j2ee</groupId>
     <artifactId>jakarta.management.j2ee-api</artifactId>
     <version>1.1.3-SNAPSHOT</version>
-    
+
     <properties>
         <non.final>false</non.final>
         <extension.name>javax.management.j2ee</extension.name>
         <spec.version>1.1</spec.version>
-        <bundle.symbolicName>javax.management.j2ee-api</bundle.symbolicName>         
+        <bundle.symbolicName>javax.management.j2ee-api</bundle.symbolicName>
         <vendor.name>Eclipse Project for Stable EE4J APIs</vendor.name>
         <implementation.vendor.id>org.glassfish</implementation.vendor.id>
         <findbugs.version>2.3.1</findbugs.version>
@@ -114,7 +114,7 @@
                     <exclude>META-INF/README</exclude>
                 </excludes>
             </resource>
-        </resources>        
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -147,7 +147,7 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>             
+            </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -161,8 +161,8 @@
                         <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
                         <Extension-Name>${spec.extension.name}</Extension-Name>
                         <Implementation-Version>${spec.implementation.version}</Implementation-Version>
-                        <Specification-Version>${spec.specification.version}</Specification-Version>                           
-                        <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>                        
+                        <Specification-Version>${spec.specification.version}</Specification-Version>
+                        <Bundle-SymbolicName>${bundle.symbolicName}</Bundle-SymbolicName>
                         <Bundle-Description>
                             Java(TM) Management ${spec.version} API Design Specification
                         </Bundle-Description>
@@ -231,7 +231,7 @@
                     <execution>
                        <id>attach-sources</id>
                        <goals>
-                           <goal>jar-no-fork</goal> 
+                           <goal>jar-no-fork</goal>
                        </goals>
                     </execution>
                 </executions>
@@ -265,7 +265,7 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>     
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
@@ -302,7 +302,7 @@
                                     <excludeFilterFile>${findbugs.exclude}</excludeFilterFile>
                                 </configuration>
                             </plugin>
-                        </plugins>                        
+                        </plugins>
                     </reporting>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>org.eclipse.ee4j.management-api</groupId>
@@ -44,7 +44,7 @@
         <non.final>false</non.final>
         <extension.name>javax.management.j2ee</extension.name>
         <spec.version>1.1</spec.version>
-        <bundle.symbolicName>javax.management.j2ee-api</bundle.symbolicName>         
+        <bundle.symbolicName>javax.management.j2ee-api</bundle.symbolicName>
         <vendor.name>Eclipse Project for Stable EE4J APIs</vendor.name>
         <implementation.vendor.id>org.glassfish</implementation.vendor.id>
         <findbugs.version>2.3.1</findbugs.version>

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -26,7 +26,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
   of the form: "Copyright (c) [$date-of-document]
-  Eclipse Foundation, Inc. <<url to this license>>"
+  Eclipse Foundation, Inc. \<<url to this license>>"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,

--- a/spec/src/main/asciidoc/management-spec.adoc
+++ b/spec/src/main/asciidoc/management-spec.adoc
@@ -4,7 +4,7 @@
 
 = Jakarta Management 1.1
 :authors: Jakarta Management Team, https://projects.eclipse.org/projects/ee4j.jakartaee-stable
-:email: https://dev.eclipse.org/mailman/listinfo/management-api-dev
+:email: https://dev.eclipse.org/mailman/listinfo/jakarta-stable-dev
 :version-label!:
 :doctype: book
 :license: Eclipse Foundation Specification License v1.0


### PR DESCRIPTION
The major change is that the parent pom reference in the api directory had to be updated.  There were several "whitespace" corrections as well.