### PR TITLE
need to add groupId to spec pom

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -22,7 +22,9 @@
         <artifactId>management-api-parent</artifactId>
         <version>1.1.3-SNAPSHOT</version>
     </parent>
+
     <modelVersion>4.0.0</modelVersion>
+    <groupId>jakarta.management.j2ee</groupId>
     <artifactId>management-spec</artifactId>
     <packaging>pom</packaging>
     <name>Jakarta Management Specification</name>


### PR DESCRIPTION
The generated spec was going to the wrong .m2 repo location.  Added the \<groupId\> to the spec's pom.xml.