### PR TITLE
revert the groupid to jakarta

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.eclipse.ee4j.management-api</groupId>
+        <groupId>jakarta.management.j2ee</groupId>
         <artifactId>management-api-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version>1.0.5</version>
     </parent>
 
-    <groupId>org.eclipse.ee4j.management-api</groupId>
+    <groupId>jakarta.management.j2ee</groupId>
     <artifactId>management-api-parent</artifactId>
     <packaging>pom</packaging>
     <version>1.1.4-SNAPSHOT</version>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -18,7 +18,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
-        <groupId>org.eclipse.ee4j.management-api</groupId>
+        <groupId>jakarta.management.j2ee</groupId>
         <artifactId>management-api-parent</artifactId>
         <version>1.1.4-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
Signed-off-by: Kevin Sutter <kwsutter@gmail.com>

The previous changes using the org.eclipse.ee4j... maven groupid caused issues with the Jenkins jobs due to insufficient privileges.  To make some quick progress, we're going to revert these groupids back to the jakarta naming convention.  We still need to modify something to prevent the parent and spec artifacts from going to maven...  